### PR TITLE
Update go version to 1.19 in go.mod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opiproject/goopicsi
 
-go 1.18
+go 1.19
 
 require (
 	github.com/opiproject/opi-api v0.0.0-20220915151511-9e129b0e199f


### PR DESCRIPTION
[Update go version to 1.19 in go.mod](https://github.com/opiproject/goopicsi/commit/fee7cc068c228a4bc04709e32971674f98e6a74d)